### PR TITLE
feat: add trait:filterable Amplience support

### DIFF
--- a/src/amplience/common.ts
+++ b/src/amplience/common.ts
@@ -237,17 +237,21 @@ export const definitionUri = (type: ts.Type, schemaHost: string) =>
  * Returns sortable trait path for amplience based on properties containing the `@sortable` tag
  * @returns Object that can be pushed to `trait:sortable` directly
  */
-export const sortableTrait = (type: ts.Type) => ({
-  sortBy: [
-    {
-      key: 'default',
-      paths: type
-        .getProperties()
-        .filter((m) => hasTag(m, 'sortable'))
-        .map((n) => `/${n.name}`),
-    },
-  ],
-})
+export const sortableTrait = (type: ts.Type) => {
+  const sortableProperties = type.getProperties().filter((m) => hasTag(m, 'sortable'))
+
+  if (sortableProperties.length === 0) return undefined
+
+  return {
+    sortBy: [
+      {
+        key: 'default',
+        paths: sortableProperties
+          .map((n) => `/${n.name}`),
+      },
+    ]
+  }
+}
 
 /**
  * Returns hierarchy trait child content types with the current type and any other
@@ -263,3 +267,22 @@ export const hierarchyTrait = (type: ts.Type, schemaHost: string) => ({
       .map((n) => `${schemaHost}/${paramCase(n.name)}`),
   ],
 })
+
+/**
+ * Returns filterable trait path for amplience based on properties containing the `@filterable` tag
+ * @returns Object that can be pushed to `trait:filterable` directly
+ */
+export const filterableTrait = (type: ts.Type) => {
+  const filterableProperties = type.getProperties().filter((m) => hasTag(m, 'filterable'))
+
+  if (filterableProperties.length === 0) return undefined
+
+  return {
+    filterBy: [
+      {
+        paths: filterableProperties
+          .map((n) => `/${n.name}`),
+      },
+    ]
+  }
+}

--- a/src/amplience/content-type.ts
+++ b/src/amplience/content-type.ts
@@ -8,6 +8,7 @@ import {
   description,
   sortableTrait,
   hierarchyTrait,
+  filterableTrait,
 } from './common'
 import { capitalCase } from 'change-case'
 import { hasSymbolFlag, hasTag } from '../lib/util'
@@ -26,6 +27,8 @@ export const contentTypeSchemaBody = (
   ...refType(AMPLIENCE_TYPE.CORE.Content),
   title: capitalCase(type.symbol.name),
   description: description(type.symbol, checker) ?? capitalCase(type.symbol.name),
+  'trait:sortable': sortableTrait(type),
+  'trait:filterable': filterableTrait(type),
   type: 'object',
   properties: {
     ...objectProperties(type, checker, schemaHost),

--- a/src/amplience/types.ts
+++ b/src/amplience/types.ts
@@ -27,6 +27,7 @@ export interface AmplienceContentTypeSchema {
   allOf: any[]
   title: string
   description: string
+  'trait:filterable'?: {},
   'trait:hierarchy'?: {},
   'trait:sortable'?: {},
   type: 'object'

--- a/test/amplience/generator.test.ts
+++ b/test/amplience/generator.test.ts
@@ -16,6 +16,7 @@ it.each([
   ['partial', 'content-link'],
   ['partial', 'base'],
   ['content-type', 'site-menu-hierarchy'],
+  ['content-type', 'category-meta'],
 ])('correct JSON files for %s %s', (type, name) => {
   const jsonPath = './test/amplience/testdata/expected'
   const result = pruned(

--- a/test/amplience/testdata/category-meta.ts
+++ b/test/amplience/testdata/category-meta.ts
@@ -1,0 +1,11 @@
+/**
+ * @content
+ */
+export interface CategoryMeta {
+  title: string
+  description?: string
+  /** @sortable */
+  order: number
+    /** @filterable */
+  prettyURL: string
+}

--- a/test/amplience/testdata/expected/content-type-schemas/category-meta.content-type.json
+++ b/test/amplience/testdata/expected/content-type-schemas/category-meta.content-type.json
@@ -1,0 +1,5 @@
+{
+  "body": "./schemas/category-meta-schema.json",
+  "schemaId": "https://schema-examples.com/category-meta",
+  "validationLevel": "CONTENT_TYPE"
+}

--- a/test/amplience/testdata/expected/content-type-schemas/schemas/category-meta-schema.json
+++ b/test/amplience/testdata/expected/content-type-schemas/schemas/category-meta-schema.json
@@ -1,0 +1,60 @@
+{
+  "$id": "https://schema-examples.com/category-meta",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "allOf": [
+    {
+      "$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/content"
+    }
+  ],
+  "title": "Category Meta",
+  "description": "Category Meta",
+  "trait:sortable": {
+    "sortBy": [
+      {
+        "key": "default",
+        "paths": [
+          "/order"
+        ]
+      }
+    ]
+  },
+  "trait:filterable": {
+    "filterBy": [
+      {
+        "paths": [
+          "/prettyURL"
+        ]
+      }
+    ]
+  },
+  "type": "object",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    },
+    "order": {
+      "title": "Order",
+      "type": "integer"
+    },
+    "prettyURL": {
+      "title": "Pretty Url",
+      "type": "string"
+    }
+  },
+  "propertyOrder": [
+    "title",
+    "description",
+    "order",
+    "prettyURL"
+  ],
+  "required": [
+    "title",
+    "order",
+    "prettyURL"
+  ]
+}

--- a/test/amplience/testdata/expected/content-types/category-meta.json
+++ b/test/amplience/testdata/expected/content-types/category-meta.json
@@ -1,0 +1,15 @@
+{
+  "contentTypeUri": "https://schema-examples.com/category-meta",
+  "status": "ACTIVE",
+  "settings": {
+    "label": "Category Meta",
+    "icons": [
+      {
+        "size": 256,
+        "url": "https://bigcontent.io/cms/icons/ca-types-primitives.png"
+      }
+    ],
+    "visualizations": [],
+    "cards": []
+  }
+}


### PR DESCRIPTION
We can discuss whether or not it should have ifs or not :P TBH I had problems with a proper debugger and actually had a bug when I tried to do a fancy ternary operator version (also makes it harder/impossible to get the sortable/filterable properties only once); 

```
/**
 * Returns filterable trait path for amplience based on properties containing the `@filterable` tag
 * @returns Object that can be pushed to `trait:filterable` directly
 */
export const filterableTrait = (type: ts.Type) =>
  type.getProperties().filter((m) => hasTag(m, 'filterable')).length === 0 ?
    undefined : {
    filterBy: [
      {
        paths: type
          .getProperties()
          .filter((m) => hasTag(m, 'filterable'))
          .map((n) => `/${n.name}`),
      },
    ]
  }
```